### PR TITLE
Utilize Jekyll Liquid Filters and baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,6 @@ description: > # this means to ignore newlines until the next key
 
 email: opensource@godaddy.com
 url: "https://godaddy.github.io"
-baseurl: "/engineering"
 permalink: pretty
 
 analytics_id: UA-37178807-20

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ description: > # this means to ignore newlines until the next key
 
 email: opensource@godaddy.com
 url: "https://godaddy.github.io"
+baseurl: "/engineering"
 permalink: pretty
 
 analytics_id: UA-37178807-20

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ description: > # this means to ignore newlines until the next key
 
 email: opensource@godaddy.com
 url: "https://godaddy.github.io"
+permalink: pretty
 
 analytics_id: UA-37178807-20
 applicant_source: APPLICANT_SOURCE-3-119
@@ -23,10 +24,10 @@ theme_settings:
   copyright_text: >
     Copyright © 1999 - 2018 GoDaddy Operating Company, LLC. All Rights Reserved.
 
-permalink: pretty
 plugins:
   - jekyll-feed
   - jekyll-sitemap
+  
 sass:
   sass_dir: ./_stylesheets
   style: compressed

--- a/_includes/block/head.html
+++ b/_includes/block/head.html
@@ -14,18 +14,18 @@
   <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/images/apple-touch-icon.png' | relative_url }}">
   <link rel="icon" type="image/png" sizes="32x32" href="{{ '/assets/images/favicon-32x32.png' | relative_url }}">
   <link rel="icon" type="image/png" sizes="16x16" href="{{ '/assets/images/favicon-16x16.png' | relative_url }}">
-  <link rel="manifest" href="/site.webmanifest">
+  <link rel="manifest" href="{{ '/site.webmanifest' | relative_url }}">
   {% feed_meta %}
 
   {% if page.canonical %}
   <link rel="canonical" href="{{ page.canonical }}">
   {% else %}
-  <link rel="canonical" href="{{ site.url }}{{ page.url}}">
+  <link rel="canonical" href="{{ site.url }}{{ page.url }}">
   {% endif %}
 
   <meta property="og:locale" content="en_US">
   <meta property="og:site_name" content="{{ site.title }}">
-  <meta property="og:url" content="{{ site.url }}{{ page.url}}">
+  <meta property="og:url" content="{{ site.url }}{{ page.url }}">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@GodaddyOSS">
 

--- a/_includes/component/author-panel.html
+++ b/_includes/component/author-panel.html
@@ -15,8 +15,8 @@
     {% for author in page.authors %}
     <div class="col-12{% if page.authors.size > 1 %} col-md-6{% endif %}">
       <div class="author mb-3">
-        <a href="{{ author.url }}">
-          <img class="rounded mr-2" src="{{ author.photo }}" alt="{{ author.name }}" width="64">
+        <a href="{{ author.url | relative_url }}">
+          <img class="rounded mr-2" src="{{ author.photo | relative_url }}" alt="{{ author.name }}" width="64">
           <span class="author-details">
             <h6>{{ author.name }}</h6>
             {% if author.title %}

--- a/_includes/component/navigation.html
+++ b/_includes/component/navigation.html
@@ -6,7 +6,7 @@
 </nav>
 
 <nav class="navbar navbar-top navbar-expand-md navbar-light bg-white">
-  <a class="navbar-brand font-weight-bold" href="{{ '/' | absolute_url }}" title="GoDaddy Engineering">
+  <a class="navbar-brand font-weight-bold" href="{{ '/' | relative_url }}" title="GoDaddy Engineering">
     {{ site.theme_settings.title | default: site.title }}
   </a>
 
@@ -20,7 +20,7 @@
       {% for item in items %}
       {% if item.title and item.hide != true %}
       <li class="nav-item{% if item.url == page.url %} active{% endif %}">
-        <a class="nav-link font-weight-bold" href="{{ item.url }}" title="{{ item.title }}">
+        <a class="nav-link font-weight-bold" href="{{ item.url | relative_url }}" title="{{ item.title }}">
           {{ item.title }}
         </a>
       </li>

--- a/_includes/component/post-card.html
+++ b/_includes/component/post-card.html
@@ -1,15 +1,15 @@
 <div class="card card--post mb-3 shadow hoverable border-0">
-  <a href="{{ post.url }}">
-    <img class="card-img-top" src="{{ post.cover }}" alt="Article featured image">
+  <a href="{{ post.url | relative_url }}">
+    <img class="card-img-top" src="{{ post.cover | relative_url }}" alt="Article featured image">
   </a>
 
   <div class="card-body">
-    <a href="{{ post.url }}" title="{{ post.title }}"><h5 class="card-title text-font-headline text-line-height-2x">{{ post.title }}</h5></a>
+    <a href="{{ post.url | relative_url }}" title="{{ post.title }}"><h5 class="card-title text-font-headline text-line-height-2x">{{ post.title }}</h5></a>
 
     <p class="card-text">
       <span class="text-muted">{{ post.date | date: '%B %d, %Y' }} — </span>
       {{ post.excerpt }}
-      <a href="{{ post.url }}" title="{{ post.title }}" role="button">
+      <a href="{{ post.url | relative_url }}" title="{{ post.title }}" role="button">
         Read More &raquo;
       </a>
     </p>

--- a/_includes/component/recent-posts.html
+++ b/_includes/component/recent-posts.html
@@ -6,7 +6,7 @@
 
         <div class="list-group">
           {% for post in site.posts limit:3 %}
-            <a href="{{ post.url }}" title="Read post" class="list-group-item list-group-item-action flex-column align-items-start">
+            <a href="{{ post.url | relative_url}}" title="Read post" class="list-group-item list-group-item-action flex-column align-items-start">
               <div class="d-flex w-100 justify-content-between">
                 <h5 class="mb-1 text-font-headline">{{ post.title }}</h5>
                 <small class="text-right">{{ post.date | date: '%B %d, %Y' }}</small>
@@ -14,7 +14,7 @@
               <p class="mb-1">{{ post.excerpt }}</p>
               <small>
                 {% for author in post.authors %}
-                By <img class="rounded mx-1" src="{{ author.photo }}" alt="{{ author.name }}" width="14">
+                By <img class="rounded mx-1" src="{{ author.photo | relative_url }}" alt="{{ author.name }}" width="14">
                 {{ author.name }}
                 {% endfor %}
               </small>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ widgets:
 {% include section/header.html %}
 
 {% if page.options contains 'full-bleed-cover' %}
-<div class="cover-image" style="background-image: url({{ page.cover }});"></div>
+<div class="cover-image" style="background-image: url({{ page.cover | relative_url }});"></div>
 {% endif %}
 
 <div class="container text-line-height-2x pt-3">

--- a/_posts/2018-06-06-cicd-best-practices.md
+++ b/_posts/2018-06-06-cicd-best-practices.md
@@ -109,7 +109,7 @@ running on the build agent.
 1. deploys the image to a single instance (canary environment) using Kubernetes, and ensure it can run without issues for a small period of time (typically 2 minutes) while serving production traffic
 1. deploys the image to our production environment
 
-![Typical pipeline](/assets/images/cicd/typical-pipeline.png "A typical pipeline showing parallel steps")
+![Typical pipeline]({{site.baseurl}}/assets/images/cicd/typical-pipeline.png "A typical pipeline showing parallel steps")
 
 Pipelines that build multiple artifacts could also build those artifacts in parallel.
 
@@ -263,7 +263,7 @@ service that pings the Jenkins REST api to determine the current status, but the
 1. We use the [Github Autostatus Jenkins plugin](https://wiki.jenkins.io/display/JENKINS/Github+Autostatus+Plugin)
 for monitoring health of our jobs over time. This has allowed us to identify which areas of the build might need improvement. It allows you to build dashboards like the following, which shows build pass rate, average build time, and count of specific stage errors.
 
-![Sample dashboard](/assets/images/cicd/sample-build-dashboard.png "A dashboard built from the Jenkins Github Autostatus Plugin")
+![Sample dashboard]({{site.baseurl}}/assets/images/cicd/sample-build-dashboard.png "A dashboard built from the Jenkins Github Autostatus Plugin")
 
 This is useful for finding stages which fail too often, and for debugging build inefficiencies.
 

--- a/_posts/2018-06-12-announcing-winston-3.md
+++ b/_posts/2018-06-12-announcing-winston-3.md
@@ -186,7 +186,7 @@ for large teams & enterprises as Node.js itself.
 This LTS goal is a core reason why this release took three years to ship.
 Let's look at a recent release chart for Node.js LTS:
 
-![](/assets/images/nodejs-lts-releases.png)
+![]({{site.baseurl}}/assets/images/nodejs-lts-releases.png)
 
 As you can see `node@4` entered "end of life" in April 2018. Until then it was
 in the active support matrix for `winston` releases. Since ES6 features

--- a/_posts/2018-06-19-jenkins-build-monitoring-plugin.md
+++ b/_posts/2018-06-19-jenkins-build-monitoring-plugin.md
@@ -18,7 +18,7 @@ we use on my team at GoDaddy. One of the best practices was:
 Most of our pipelines provide per-stage status checks shown on
 the GitHub PR page. For example:
 
- ![PR Page showing status checks](/assets/images/monitoring-plugin/pr-build-page.png)
+ ![PR Page showing status checks]({{site.baseurl}}/assets/images/monitoring-plugin/pr-build-page.png)
 
 Our engineers like this because they don't have to leave GitHub so see whether the PR built successfully.
 
@@ -132,7 +132,7 @@ In the rest of this article, I'll talk about the high-level design of the plugin
 
 The following class diagram shows the architecture of the plugin.
 
-![GitHub autostatus plugin class diagram](/assets/images/monitoring-plugin/github-autostatus-design.png)
+![GitHub autostatus plugin class diagram]({{site.baseurl}}/assets/images/monitoring-plugin/github-autostatus-design.png)
 
 ### Job watching components
 
@@ -177,13 +177,13 @@ pipeline {
 
 The **Pipeline Steps** build action links to this page:
 
-![Pipeline steps](/assets/images/monitoring-plugin/flowgraph-table.png)
+![Pipeline steps]({{site.baseurl}}/assets/images/monitoring-plugin/flowgraph-table.png)
 
 You can see representations for every stage and step in the plugin, plus additional stuff added by Jenkins automatically.
 
 `onNewHead(flowNode)` is called with the following flowNodes.
 
-![Flownodes](/assets/images/monitoring-plugin/flownode-table.png)
+![Flownodes]({{site.baseurl}}/assets/images/monitoring-plugin/flownode-table.png)
 
 StepStartNode Flow nodes contain additional properties to help identify their purpose,
 but that's enough detail for this example.

--- a/_posts/2018-07-10-react-native-wdio.md
+++ b/_posts/2018-07-10-react-native-wdio.md
@@ -43,7 +43,7 @@ npm install webdriverio -g
 wdio config
 ```
 
-![Screenshot showing wdio config](/assets/images/react-native-wdio/wdio-config.png)
+![Screenshot showing wdio config]({{site.baseurl}}/assets/images/react-native-wdio/wdio-config.png)
 
 Follow the prompts to create a base WebDriverIO configuration as shown in the above picture.
 
@@ -171,7 +171,7 @@ Run the UI test:
 wdio wdio.conf.js
 ```
 
-![Screenshot showing wdio output](/assets/images/react-native-wdio/wdio-output.png)
+![Screenshot showing wdio output]({{site.baseurl}}/assets/images/react-native-wdio/wdio-output.png)
 
 Now, you have a WebdriverIO UI test running against the local emulator. You are now set to explore [WebDriverIO Mobile API](http://webdriver.io/api.html) to continue writing more complete UI tests.
 

--- a/_posts/2018-10-16-cypress-vs-selenium.md
+++ b/_posts/2018-10-16-cypress-vs-selenium.md
@@ -46,7 +46,7 @@ We struggled to get wide adoption in teams for writing UI tests. Therefore scali
 
 Even with all of the extensions, improvements and wrappers we built into our custom framework developer interest remains low and maintenance remains high. 
 
-![Screenshot showing Selenium Test After Run](/assets/images/cypress/selenium-test.png)
+![Screenshot showing Selenium Test After Run]({{site.baseurl}}/assets/images/cypress/selenium-test.png)
 
 Some of the problems we encountered: 
 
@@ -95,14 +95,14 @@ $ npx cypress open
 
 The Cypress Test Runner will load with a pre-loaded set of tests which run against a Cypress example [application](https://github.com/cypress-io/cypress-example-kitchensink).
 
-![Screenshot showing Cypress Test Runner Start](/assets/images/cypress/ide.png)
+![Screenshot showing Cypress Test Runner Start]({{site.baseurl}}/assets/images/cypress/ide.png)
 
 ### Clear Documentation
  
 In addition to the detailed guides provided on the Cypress website, Cypress provides a search capability on their 
 documentation site helping to find answers quicker.
 
-![Screenshot showing Cypress Search](/assets/images/cypress/search.png)
+![Screenshot showing Cypress Search]({{site.baseurl}}/assets/images/cypress/search.png)
 
 Similar to Selenium, Cypress is also [open source](https://github.com/cypress-io/cypress) which has allowed us to look
  at their code to find how it works and provided insight into issues others have run into providing potential 
@@ -156,7 +156,7 @@ to write Cypress tests is minimal. The learning curve is drastically reduced by:
 One of the more impressive features of Cypress is the Test Runner. Inside the Test Runner, Cypress offers a Selector 
 Playground that can be used to generate selectors for your tests.
 
-![Screenshot showing Element Selector](/assets/images/cypress/elementselector.png) 
+![Screenshot showing Element Selector]({{site.baseurl}}/assets/images/cypress/elementselector.png) 
 
 Gone are the days of inspecting elements or hunting through page source to generate a selector. Cypress defines a 
 strategy of finding the best unique selector and provides the command needed within your test code. In the above 
@@ -167,7 +167,7 @@ selector for your element.
 
 Another feature of the Test Runner is the Command Log which details every step of the test.
 
-![Screenshot showing Cypress Test Runner Running](/assets/images/cypress/testrunner.png)
+![Screenshot showing Cypress Test Runner Running]({{site.baseurl}}/assets/images/cypress/testrunner.png)
 
 On the left side a list of commands will show exactly what request was made making it easy to debug when problems 
 arise. On the GoDaddy GoCentral team, we use a testing environment to verify new features before deploying to our 
@@ -176,7 +176,7 @@ services maintained by teams throughout the company and sometimes one of those s
 example below you can see a call to one of our APIs that is returning a 404 response. This allows us to debug our 
 test and inspect the request and response made to determine if our test is working properly.
 
-![Screenshot showing Cypress debugging](/assets/images/cypress/debugging.png)
+![Screenshot showing Cypress debugging]({{site.baseurl}}/assets/images/cypress/debugging.png)
 
 ### Mocking Flaky APIs
 
@@ -208,7 +208,7 @@ avoiding making the actual call to the service. We can also guarantee that our t
  race condition. We also simulated the JSON response received from the endpoint. This can be useful when wanting to 
  test various responses without having to setup test data before each test. 
  
-![Screenshot showing 204 mocking](/assets/images/cypress/204mocking.png)
+![Screenshot showing 204 mocking]({{site.baseurl}}/assets/images/cypress/204mocking.png)
  
 Another useful example of mocking responses is to verify UI functionality when things go bad. With Cypress, it's easy
  to simulate what an error might look like to a customer when a service outage occurs.
@@ -226,7 +226,7 @@ cy.route({
 With the above code, we can simulate our endpoint returning a 500 response to verify the customer sees the 
 appropriate error message on their screen
 
-![Screenshot showing 500 mocking](/assets/images/cypress/500mocking.png)
+![Screenshot showing 500 mocking]({{site.baseurl}}/assets/images/cypress/500mocking.png)
 
 ## Best Practices (or what we've learned so far)
 

--- a/_posts/2018-10-28-google-lighthouse-as-a-service-lighthouse4u.md
+++ b/_posts/2018-10-28-google-lighthouse-as-a-service-lighthouse4u.md
@@ -83,7 +83,7 @@ of SVG cards surfaced directly in your Markdown or HTML.
 ```
 ![SVG card](/api/website/compare?q1=documentId:${id1}&q2=documentId:${id2}&format=svg)
 ```
-![Compare SVG](/assets/images/lh4u/widget%20compare%20-%20about.jpg)
+![Compare SVG]({{site.baseurl}}/assets/images/lh4u/widget%20compare%20-%20about.jpg)
 
 
 ## Advanced Visualization
@@ -98,7 +98,7 @@ on grouping of results, time ranges, domains, scores and more is a powerful util
 Here we find our Kibana dashboard showing us how our website is performing over
 time to learn from the changes we're making.
 
-![Kibana Perf](/assets/images/lh4u/kibana%20-%20overall%20-%20about.jpg)
+![Kibana Perf]({{site.baseurl}}/assets/images/lh4u/kibana%20-%20overall%20-%20about.jpg)
 
 ### Competition
 
@@ -106,7 +106,7 @@ Yep we even
 [compare (favorably) against competition](https://www.godaddy.com/garage/site-speed-small-business-website-white-paper/)!
 Names redacted, but we're on the high end in case you're curious.
 
-![Kibana Competitor Comparison](/assets/images/lh4u/kibana%20-%20product%20comparisons.jpg)
+![Kibana Competitor Comparison]({{site.baseurl}}/assets/images/lh4u/kibana%20-%20product%20comparisons.jpg)
 
 
 
@@ -116,7 +116,7 @@ LH4U has two requirements, [Elasticsearch](https://www.elastic.co/downloads/elas
 and an AMQP-compatible Queue (we use [RabbitMQ](https://www.rabbitmq.com/download.html)).
 Both requirements are opensource and easy to setup if you're not already using them.
 
-![Data Flows](/assets/images/lh4u/data%20flow.jpg)
+![Data Flows]({{site.baseurl}}/assets/images/lh4u/data%20flow.jpg)
 
 ```
 npm i -g lighthouse4u

--- a/_posts/2019-02-26-software-vpn-channel.md
+++ b/_posts/2019-02-26-software-vpn-channel.md
@@ -16,7 +16,7 @@ In general, there are two ways to build the connection: [AWS direct connect](htt
 
 ## High Level Architecture Design
 
-![OpenVPN High-Level Architecture](/assets/images/ha-openvpn/openvpn-arch.png)
+![OpenVPN High-Level Architecture]({{site.baseurl}}/assets/images/ha-openvpn/openvpn-arch.png)
 
 To configure a high-availability OpenVPN server on AWS, we used the Active-Passive HA configuration. We set up two OpenVPN servers, one primary and one secondary. We ran them simultaneously on two container instances/EC2 instances in the ECS cluster. Each container instance belonged to an auto-scaling group with a desired count 1. For each auto-scaling group, there was a dedicated auto-scaling launch configuration associated with it. In the launch configuration, we copied the OpenVPN server certs from an S3 bucket to the instance. Also, we assigned an Elastic IP to the container instance to make sure its IP address is persistent after reboot. Then, we connected each OpenVPN Server to an OpenVPN client set up on a GoDaddy VM. This gave us two OpenVPN tunnels.
 
@@ -24,7 +24,7 @@ To facilitate the OpenVPN server and client setup, we also created server and cl
 
 During any time, only one OpenVPN server (Primary OpenVPN Server) is actively being used. All traffic from AWS to the On-Premises data centers will go through that OpenVPN server. We have a CloudWatch rule defined for AWS ECS task state change event. Based on the event received, the rule will trigger a lambda function to update the route table and promote the secondary server as the primary server if the primary OpenVPN server is down. The figure below shows one such event.
 
-![Route Table Update Event](/assets/images/ha-openvpn/openvpn-route.png)
+![Route Table Update Event]({{site.baseurl}}/assets/images/ha-openvpn/openvpn-route.png)
 
 ## Auto-Recovery and Monitor
 
@@ -32,11 +32,11 @@ In the current setup, on the server side, we use AWS auto-scaling with desired c
 
 Then, we would need monitors to help us to discover any OpenVPN connection failure as soon as it happens. To do this, there is a cron job running on each ECS container instance. It pings one of our internal services at GoDaddy, and then it publishes the status metric to CloudWatch.
 
-![OpenVPN Status](/assets/images/ha-openvpn/openvpn-Status.png)
+![OpenVPN Status]({{site.baseurl}}/assets/images/ha-openvpn/openvpn-Status.png)
 
 We configured a CloudWatch alarm for each OpenVPN status metric. Once the alarm is triggered, it will send alerts to our slack channel and on-call engineers can take actions to inspect:
 
-![OpenVPN Alarms](/assets/images/ha-openvpn/openvpn-alarm.png)
+![OpenVPN Alarms]({{site.baseurl}}/assets/images/ha-openvpn/openvpn-alarm.png)
 
 ## Conclusion
 

--- a/_posts/2019-04-09-announcing-exemplar.md
+++ b/_posts/2019-04-09-announcing-exemplar.md
@@ -86,7 +86,7 @@ buttons at once:
 npm run storybook
 ```
 
-![](/assets/images/exemplar/buttons.png)
+![]({{site.baseurl}}/assets/images/exemplar/buttons.png)
 
 ## What's Next?
 

--- a/_posts/2019-04-16-kubernetes-external-secrets.md
+++ b/_posts/2019-04-16-kubernetes-external-secrets.md
@@ -141,7 +141,7 @@ secret data from the specified external secret management system, and automatica
 creates native `Secret` objects that hold the secret data. The
 architecture diagram below illustrates this process.
 
-![Architecture Diagram](/assets/images/kubernetes-external-secrets/architecture.png)
+![Architecture Diagram]({{site.baseurl}}/assets/images/kubernetes-external-secrets/architecture.png)
 
 ## Using
 

--- a/_posts/2019-05-22-testing-react-native-using-ekke.md
+++ b/_posts/2019-05-22-testing-react-native-using-ekke.md
@@ -20,7 +20,7 @@ execution of tests directly **inside your React-Native application**. `ekke`
 allows your tests to fully access every API that the platform has to offer.
 
 <p align="center">
-  <img width="800" height="607" src="/assets/images/ekke/ekke-react-native-intro.gif" />
+  <img width="800" height="607" src="{{site.baseurl}}/assets/images/ekke/ekke-react-native-intro.gif" />
   <br />
   <sub>Ekke in action: running a test suite inside React-Native and streaming results back to the CLI</sub>
 </p>
@@ -162,7 +162,7 @@ And watch the magic unfold. The sequence of events that will happen:
 - Closes the process with exit code 0 if your tests pass, or 1 when there was
   a failure.
 
-![Our test suite passes](/assets/images/ekke/ekke-result.png)
+![Our test suite passes]({{site.baseurl}}/assets/images/ekke/ekke-result.png)
 
 It's that simple to use `ekke`. The project is now available on:
 

--- a/_posts/2019-06-18-react-native-community-contribution-datetimepicker-component.md
+++ b/_posts/2019-06-18-react-native-community-contribution-datetimepicker-component.md
@@ -162,8 +162,8 @@ The component comes with a runnable [React Native example app][example] that
 uses the new component. Below are examples of the date and time picker on both
 platforms.
 
-![DatePicker on iOS](/assets/images/datetimepicker/ios-datepicker.png)
-![TimePicker on Android](/assets/images/datetimepicker/android-timepicker.png)
+![DatePicker on iOS]({{site.baseurl}}/assets/images/datetimepicker/ios-datepicker.png)
+![TimePicker on Android]({{site.baseurl}}/assets/images/datetimepicker/android-timepicker.png)
 
 This contribution to the [lean core initiative][leancore] will allow the
 community to continue adding new features and bug fixes to the React Native
@@ -186,5 +186,5 @@ for the new module.
 [eslint]: https://www.npmjs.com/package/@react-native-community/eslint-config
 [orb]: https://github.com/react-native-community/react-native-circleci-orb/
 [Detox]: https://github.com/wix/detox/
-[ekke]: /2019/05/22/testing-react-native-using-ekke/
+[ekke]: {{site.baseurl}}/2019/05/22/testing-react-native-using-ekke/
 [install]: https://github.com/react-native-community/react-native-datetimepicker/#getting-started

--- a/_posts/2019-06-25-asherah-opensource-app-encryption-sdk.md
+++ b/_posts/2019-06-25-asherah-opensource-app-encryption-sdk.md
@@ -148,7 +148,7 @@ String decryptedPayloadString = new String(encryptionSessionBytes.decrypt(newByt
 
 Here is a diagram showing at a high level a typical encryption operation in **Asherah**:
 
-![Diagram 1](/assets/images/asherah/first.png)
+![Diagram 1]({{site.baseurl}}/assets/images/asherah/first.png)
 
 Features:
 
@@ -179,7 +179,7 @@ initialize your encryption or decryption context. A helpful and configurable `Cr
 it wraps and manages the complexity of key rotation schedules and caching behavior, among other things. Future **Asherah** 
 features will primarily be exposed via the policy.
 
-![Diagram 2](/assets/images/asherah/envelope.png)
+![Diagram 2]({{site.baseurl}}/assets/images/asherah/envelope.png)
 
 Envelope encryption is a method for managing and storing key material alongside the data that the key encrypts. In this 
 model, when you encrypt a data element, you take the key you used to encrypt the data, encrypt the **key** with a separate,
@@ -194,7 +194,7 @@ Security Products page](https://cloud.google.com/kms/docs/envelope-encryption).
 
 The notion of higher and lower order keys can be generalized to a hierarchy or tree of keys:
 
-![Diagram 3](/assets/images/asherah/key_hierarchy.png)
+![Diagram 3]({{site.baseurl}}/assets/images/asherah/key_hierarchy.png)
 
 The key hierarchy here has several tiers, each of which you can use to partition your data. A good example of a plausible
 data partitioning scheme would be to assign each service in your infrastructure a separate SK. Then, assign each customer in 
@@ -205,7 +205,7 @@ different service.
 In order to see how all of these pieces fit together, let's take a look a sequence diagram of a encrypting a
 payload using **Asherah**:
 
-![Diagram 4](/assets/images/asherah/happy_path_create_all_keys.svg)
+![Diagram 4]({{site.baseurl}}/assets/images/asherah/happy_path_create_all_keys.svg)
 
 The level of complexity increases significantly when different levels of keys are in need of rotation or are
 stale in the cache. All of this complexity is already implemented for you in **Asherah**!


### PR DESCRIPTION
modified layouts and components to utilize Jekyll Liquid Filters as Well as prepending the site.baseurl to relative links in posts. This does not have any change to the site other than allowing us to make the switch to a new baseurl when the blog moves to /engineering.