### PR TITLE
fix: canonical links still pointing to the the old blog URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ description: > # this means to ignore newlines until the next key
   to build and market their digital identities.
 
 email: opensource@godaddy.com
-url: "https://godaddy.github.io"
+url: "https://godaddy.com"
 baseurl: "/engineering"
 permalink: pretty
 
@@ -28,7 +28,7 @@ theme_settings:
 plugins:
   - jekyll-feed
   - jekyll-sitemap
-  
+
 sass:
   sass_dir: ./_stylesheets
   style: compressed

--- a/_includes/block/head.html
+++ b/_includes/block/head.html
@@ -20,19 +20,19 @@
   {% if page.canonical %}
   <link rel="canonical" href="{{ page.canonical }}">
   {% else %}
-  <link rel="canonical" href="{{ site.url }}{{ page.url }}">
+  <link rel="canonical" href="{{ site.url }}{{ site.baseurl }}{{ page.url }}">
   {% endif %}
 
   <meta property="og:locale" content="en_US">
   <meta property="og:site_name" content="{{ site.title }}">
-  <meta property="og:url" content="{{ site.url }}{{ page.url }}">
+  <meta property="og:url" content="{{ site.url }}{{site.baseurl}}{{ page.url }}">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@GodaddyOSS">
 
   {% if page.cover %}
-  <meta property="og:image" content="{{ site.url }}{{ page.cover }}">
+  <meta property="og:image" content="{{ site.url }}{{site.baseurl}}{{ page.cover }}">
   {% else %}
-  <meta property="og:image" content="{{ site.url }}/assets/images/banner.png">
+  <meta property="og:image" content="{{ site.url }}{{site.baseurl}}/assets/images/banner.png">
   {% endif %}
 
   {% if page.title %}


### PR DESCRIPTION
The canonical link element is still pointing to the blogs old URL, and I believe this is the root cause of some issues with the content being shared on various social platforms.

This PR corrects that, and also corrects an issue with the OG image not including the base URL.

### Screenshots

Showing a blog post still loading images correctly in local env:

<img width="959" alt="Screen Shot 2019-12-06 at 12 40 46 PM" src="https://user-images.githubusercontent.com/1934719/70355165-51e4e280-1826-11ea-893b-301f273e9fa4.png">

Showing the canonical link reflecting the configuration file settings:

<img width="959" alt="Screen Shot 2019-12-06 at 12 40 40 PM" src="https://user-images.githubusercontent.com/1934719/70355221-73de6500-1826-11ea-9502-d15abcb82e16.png">
