### PR TITLE
Remove the search bar for now; was proving more deceptive than useful

### DIFF
--- a/featured-projects.html
+++ b/featured-projects.html
@@ -6,8 +6,6 @@ order: 1
 excerpt: Open source projects created and maintained by GoDaddy engineers.
 ---
 
-{% include component/project-search.html %}
-
 <div class="card-deck project-cards">
   {% for project in site.data.projects %}
     {% assign mod = forloop.index | modulo: 3 %}


### PR DESCRIPTION
After talking this over with a few people and looking what it actually did (searches the 11 projects on the current page) we decided that this wasn't as useful as originally hoped, and could potentially give the impression that it was searching all of our projects. So this is being removed for now.