### PR TITLE
Swap to the Contributor Covenant to match our OSS projects

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -3,60 +3,100 @@ title: Code of Conduct
 slug: code-of-conduct
 layout: default
 order: 3
-excerpt: Diversity is one of our huge strengths. To foster open and inclusive communication, we have a few ground rules that we ask people to adhere to. This code applies equally to our employees, mentors and those seeking help and guidance.
+excerpt:  In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 ---
 
 <div class="text-line-height-2x">
-  <div class="card mb-3">
-    <div class="card-body">
-      <p class="card-text lead">
-        Diversity is one of our huge strengths. To foster open and inclusive communication, we have a few ground rules that we ask people to adhere to. This code applies equally
-        to our employees, mentors and those seeking help and guidance.
-      </p>
+  <h1 class="mb-5">Contributor Covenant Code of Conduct</h1>
 
-      <p class="card-text lead">
-        This isn’t an exhaustive list of things that you can’t do. Rather,
-        take it in the spirit in which it’s intended - a guide to make it
-        easier to enrich all of us and the technical communities in which we participate.
-      </p>
-    </div>
-  </div>
+  <h2>Our Pledge</h2>
 
   <p>
-    This code of conduct applies to all spaces managed by the GoDaddy OSS team.
-    This includes the issue tracker, and any other forums created by the team which
-    the community uses for communication. In addition, violations of this code outside
-    these spaces may affect a person's ability to participate within them.
+    In the interest of fostering an open and welcoming environment, we as
+    contributors and maintainers pledge to making participation in our project and
+    our community a harassment-free experience for everyone, regardless of age, body
+    size, disability, ethnicity, sex characteristics, gender identity and expression,
+    level of experience, education, socio-economic status, nationality, personal
+    appearance, race, religion, or sexual identity and orientation.
   </p>
 
+  <h2>Our Standards</h2>
+
   <p>
-    If you believe someone is violating the code of conduct, we ask that you report it
-    by sending a direct message to @GodaddyOSS.
+    Examples of behavior that contributes to creating a positive environment
+    include:
   </p>
 
   <ul>
-      <li>Be friendly and patient.</li>
-      <li>Be welcoming. We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.</li>
-      <li>Be considerate. Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.</li>
-      <li>Be respectful. Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the GoDaddy OSS community should be respectful when dealing with other members as well as with people outside the GoDaddy OSS community.</li>
-      <li>Be careful in the words that you choose. We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to:</li>
-      <li class="list-unstyled">
-          <ul>
-              <li>Violent threats or language directed against another person.</li>
-              <li>Discriminatory jokes and language.</li>
-              <li>Posting sexually explicit or violent material.</li>
-              <li>Posting (or threatening to post) other people's personally identifying information ("doxing").</li>
-              <li>Personal insults, especially those using racist or sexist terms.</li>
-              <li>Unwelcome sexual attention.</li>
-              <li>Advocating for, or encouraging, any of the above behavior.</li>
-              <li>Repeated harassment of others. In general, if someone asks you to stop, then stop.</li>
-          </ul>
-      </li>
-
-      <li>When we disagree, try to understand why. Disagreements, both social and technical, happen all the time and GoDaddy is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of GoDaddy comes from its varied community, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.</li>
+    <li>Using welcoming and inclusive language</li>
+    <li>Being respectful of differing viewpoints and experiences</li>
+    <li>Gracefully accepting constructive criticism</li>
+    <li>Focusing on what is best for the community</li>
+    <li>Showing empathy towards other community members</li>
   </ul>
 
   <p>
-    <i>Original text courtesy of the Django project.</i>
+    Examples of unacceptable behavior by participants include:
+  </p>
+
+  <ul>
+    <li>The use of sexualized language or imagery and unwelcome sexual attention or advances</li>
+    <li>Trolling, insulting/derogatory comments, and personal or political attacks</li>
+    <li>Public or private harassment</li>
+    <li>Publishing others' private information, such as a physical or electronic address, without explicit permission</li>
+    <li>Other conduct which could reasonably be considered inappropriate in a professional setting</li>
+  </ul>
+
+  <h2>Our Responsibilities</h2>
+
+  <p>
+    Project maintainers are responsible for clarifying the standards of acceptable
+    behavior and are expected to take appropriate and fair corrective action in
+    response to any instances of unacceptable behavior.
+
+    Project maintainers have the right and responsibility to remove, edit, or
+    reject comments, commits, code, wiki edits, issues, and other contributions
+    that are not aligned to this Code of Conduct, or to ban temporarily or
+    permanently any contributor for other behaviors that they deem inappropriate,
+    threatening, offensive, or harmful.
+  </p>
+
+  <h2>Scope</h2>
+
+  <p>
+    This Code of Conduct applies within all project spaces, and it also applies when
+    an individual is representing the project or its community in public spaces.
+    Examples of representing a project or community include using an official
+    project e-mail address, posting via an official social media account, or acting
+    as an appointed representative at an online or offline event. Representation of
+    a project may be further defined and clarified by project maintainers.
+  </p>
+
+  <h2>Enforcement</h2>
+
+  <p>
+    Instances of abusive, harassing, or otherwise unacceptable behavior may be
+    reported by contacting the project team at oss@godaddy.com. All
+    complaints will be reviewed and investigated and will result in a response that
+    is deemed necessary and appropriate to the circumstances. The project team is
+    obligated to maintain confidentiality with regard to the reporter of an incident.
+    Further details of specific enforcement policies may be posted separately.
+
+    Project maintainers who do not follow or enforce the Code of Conduct in good
+    faith may face temporary or permanent repercussions as determined by other
+    members of the project's leadership.
+  </p>
+
+  <h2>Attribution</h2>
+
+  <p>
+    This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org">Contributor
+    Covenant</a>, version 1.4, available at
+    <a href="https://www.contributor-covenant.org/version/1/4/code-of-conduct.html">https://www.contributor-covenant.org/version/1/4/code-of-conduct.html</a>
+  </p>
+
+  <p>
+    For answers to common questions about this code of conduct, see
+    <a href="https://www.contributor-covenant.org/faq">https://www.contributor-covenant.org/faq</a>
   </p>
 </div>


### PR DESCRIPTION
When the blog was first started, I recommended using the Django code of conduct, as it has done well for that community. Now as our open source work and presence has grown, we've shifted toward adopting the Contributor Covenant for our open source projects. This brings the blog into alignment with that adoption.