### PR TITLE
Fix a couple of rendering issues on the Ekke post

### DIFF
--- a/_posts/2019-05-22-testing-react-native-using-ekke.md
+++ b/_posts/2019-05-22-testing-react-native-using-ekke.md
@@ -67,7 +67,7 @@ app that you create using `react-native init`.
 
 Import the `Ekke` component and add it somewhere in your component tree:
 
-```js
+```jsx
 import YourActualApplicationHere from './some/path';
 import { Ekke } from 'ekke';
 import React from 'react';
@@ -99,7 +99,8 @@ going on underneath the covers:
 Now that the component is integrated in the application we can start writing
 our first `test.js`:
 
-```js
+```jsx
+{% raw %}
 import { View, AsyncStorage } from 'react-native';
 import { describe, it } from 'mocha';
 import { render } from 'ekke';
@@ -135,6 +136,7 @@ describe('My first Ekke test', function () {
     assume(props.width).equals(400);
   });
 });
+{% endraw %}
 ```
 
 This simple test suite will interact with the built-in `AsyncStorage` API,


### PR DESCRIPTION
There was a persistent message coming up when running Jekyll locally:

```
Liquid Warning: Liquid syntax error (line 108): Expected end_of_string but found colon in "{{ backgroundColor: 'red', width: this.props.width, height: this.props.height }}" in engineering/_posts/2019-05-22-testing-react-native-using-ekke.md
```

In looking into this, I realized that part of the post is not even rendering properly! Here are before and after shots for reference:

Before:
<img width="591" alt="Screen Shot 2020-08-05 at 12 12 56 PM" src="https://user-images.githubusercontent.com/37809/89437089-1a139f00-d715-11ea-89e6-809c41939ca1.png">

After:
<img width="592" alt="Screen Shot 2020-08-05 at 12 14 05 PM" src="https://user-images.githubusercontent.com/37809/89437156-31eb2300-d715-11ea-8441-6ea3a9f5f15a.png">
