### PR TITLE
Add a page about joining us on Slack

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -2,7 +2,7 @@
 title: Code of Conduct
 slug: code-of-conduct
 layout: default
-order: 3
+order: 5
 excerpt:  In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 ---
 

--- a/github-orgs.html
+++ b/github-orgs.html
@@ -2,7 +2,7 @@
 title: GitHub
 slug: github-orgs
 layout: default
-order: 1
+order: 3
 excerpt: GitHub orgs created and maintained by GoDaddy engineers.
 ---
 <p>

--- a/slack.html
+++ b/slack.html
@@ -1,0 +1,53 @@
+---
+title: Slack
+slug: slack
+layout: default
+order: 4
+excerpt: Come join us on Slack for discussions around our Open Source projects!
+---
+<h2>Join us on Slack!</h2>
+
+<p>
+  We use Slack for collaborating and communicating on our various Open Source
+  projects and initiatives. More voices are always wanted and welcome, so come
+  join us and help us form these technologies!
+</p>
+
+<div class="card-deck text-center">
+  <div class="card mb-3 shadow border-0">
+    <div class="card-body">
+      <h5 class="card-title text-font-headline">Step 1</h5>
+      <p class="card-text">
+        <a href="{{ site.baseurl }}{% link code-of-conduct.html %}">
+          Read our Code of Conduct
+        </a>
+      </p>
+    </div>
+  </div>
+  <div class="card mb-3 shadow border-0">
+    <div class="card-body">
+      <h5 class="card-title text-font-headline">Step 2</h5>
+      <p class="card-text">
+        <a href="http://godaddy-oss-slack.herokuapp.com/">Request Slack Invitation</a>
+      </p>
+      <p class="card-text">
+        <small>
+          <a class="text-muted" href="http://godaddy-oss-slack.herokuapp.com/">http://godaddy-oss-slack.herokuapp.com/</a>
+        </small>
+      </p>
+    </div>
+  </div>
+  <div class="card mb-3 shadow border-0">
+    <div class="card-body">
+      <h5 class="card-title text-font-headline">Step 3</h5>
+      <p class="card-text">
+        <a href="https://godaddy-oss.slack.com/">Sign in to Slack!</a>
+      </p>
+      <p class="card-text">
+        <small>
+          <a class="text-muted" href="https://godaddy-oss.slack.com/">https://godaddy-oss.slack.com/</a>
+        </small>
+      </p>
+    </div>
+  </div>
+</div>

--- a/slack.html
+++ b/slack.html
@@ -28,11 +28,11 @@ excerpt: Come join us on Slack for discussions around our Open Source projects!
     <div class="card-body">
       <h5 class="card-title text-font-headline">Step 2</h5>
       <p class="card-text">
-        <a href="http://godaddy-oss-slack.herokuapp.com/">Request Slack Invitation</a>
+        <a href="https://godaddy-oss-slack.herokuapp.com/">Request Slack Invitation</a>
       </p>
       <p class="card-text">
         <small>
-          <a class="text-muted" href="http://godaddy-oss-slack.herokuapp.com/">http://godaddy-oss-slack.herokuapp.com/</a>
+          <a class="text-muted" href="https://godaddy-oss-slack.herokuapp.com/">https://godaddy-oss-slack.herokuapp.com/</a>
         </small>
       </p>
     </div>


### PR DESCRIPTION
Our current story for joining Slack has not been great. For example, in the [tartufo contributing doc](https://tartufo.readthedocs.io/en/stable/CONTRIBUTING.html), we point directly to the Slack server, but do not tell users how to get an invitation. In the [kubernetes-external-secrets README](https://github.com/godaddy/kubernetes-external-secrets#readme), we link to the invitation page, but not the Slack server itself. And every time somebody asks me how to get to our OSS Slack server, I have to go look up the invitation link. This one page should ease that whole story. Want to join us on Slack? Go look at this one page.

And here is what it looks like:
![Screen Shot 2020-08-12 at 1 44 19 PM](https://user-images.githubusercontent.com/37809/90049216-7ee57100-dca2-11ea-8afd-d3163557a056.png)

This is very heavily shamelessly based on http://dctech.chat/ 😄 